### PR TITLE
refactor access to seckey

### DIFF
--- a/utils/index.ts
+++ b/utils/index.ts
@@ -2,3 +2,4 @@ export * from "./api";
 export * from "./musicPlayer";
 export * from "./nostr";
 export * from "./cache";
+export * from "./secureStorage";

--- a/utils/nostr.ts
+++ b/utils/nostr.ts
@@ -4,15 +4,39 @@ import "fast-text-encoding";
 // this is needed to polyfill crypto.getRandomValues which nostr-tools uses
 import "react-native-get-random-values";
 
-import { nip19, relayInit, Filter, Event } from "nostr-tools";
+import {
+  nip19,
+  relayInit,
+  Filter,
+  Event,
+  finishEvent,
+  EventTemplate,
+} from "nostr-tools";
 import {
   cacheNostrProfileEvent,
   cacheNostrRelayListEvent,
   getCachedNostrProfileEvent,
   getCachedNostrRelayListEvent,
 } from "@/utils/cache";
+import { getSeckey } from "@/utils/secureStorage";
 
 export { getPublicKey } from "nostr-tools";
+
+export const encodeNpub = (pubkey: string) => {
+  try {
+    return nip19.npubEncode(pubkey);
+  } catch {
+    return null;
+  }
+};
+
+export const encodeNsec = (seckey: string) => {
+  try {
+    return nip19.nsecEncode(seckey);
+  } catch {
+    return null;
+  }
+};
 
 export const decodeNsec = (nsec: string) => {
   try {
@@ -175,4 +199,12 @@ export const makeProfileEvent = (
     tags: [],
     content: JSON.stringify(profile),
   };
+};
+
+export const signEvent = async (eventTemplate: EventTemplate) => {
+  const seckey = await getSeckey();
+
+  if (seckey) {
+    return finishEvent(eventTemplate, seckey);
+  }
 };

--- a/utils/secureStorage.ts
+++ b/utils/secureStorage.ts
@@ -1,0 +1,15 @@
+import * as SecureStore from "expo-secure-store";
+
+const seckey = "seckey";
+
+export const saveSeckey = async (value: string) => {
+  await SecureStore.setItemAsync(seckey, value);
+};
+
+export const getSeckey = async () => {
+  return await SecureStore.getItemAsync(seckey);
+};
+
+export const deleteSeckey = async () => {
+  await SecureStore.deleteItemAsync(seckey);
+};


### PR DESCRIPTION
Seckey is now only accessed when needed from secure storage. Previously, seckey was kept in memory unencrypted.