### PR TITLE
Use default text component in full player time markers

### DIFF
--- a/components/FullSizeMusicPlayer/PlayerControls.tsx
+++ b/components/FullSizeMusicPlayer/PlayerControls.tsx
@@ -60,11 +60,9 @@ export const PlayerControls = () => {
           marginTop: -8,
         }}
       >
-        <Text style={styles.monospacedText}>{formatTime(positionInMs)}</Text>
+        <Text>{formatTime(positionInMs)}</Text>
         {durationInMs && (
-          <Text style={styles.monospacedText}>
-            -{formatTime(durationInMs - positionInMs)}
-          </Text>
+          <Text>-{formatTime(durationInMs - positionInMs)}</Text>
         )}
       </View>
       <View
@@ -98,11 +96,3 @@ export const PlayerControls = () => {
     </View>
   );
 };
-
-const styles = StyleSheet.create({
-  monospacedText: {
-    fontFamily: Platform.OS === "ios" ? "Courier New" : "monospace",
-    letterSpacing: -1,
-    fontWeight: "bold",
-  },
-});

--- a/components/FullSizeMusicPlayer/PlayerControls.tsx
+++ b/components/FullSizeMusicPlayer/PlayerControls.tsx
@@ -101,7 +101,7 @@ export const PlayerControls = () => {
 
 const styles = StyleSheet.create({
   monospacedText: {
-    fontFamily: "Helvetica",
+    fontFamily: Platform.OS === "ios" ? "Helvetica" : "Roboto",
     letterSpacing: 0.5,
   },
 });

--- a/components/FullSizeMusicPlayer/PlayerControls.tsx
+++ b/components/FullSizeMusicPlayer/PlayerControls.tsx
@@ -60,9 +60,11 @@ export const PlayerControls = () => {
           marginTop: -8,
         }}
       >
-        <Text>{formatTime(positionInMs)}</Text>
+        <Text style={styles.monospacedText}>{formatTime(positionInMs)}</Text>
         {durationInMs && (
-          <Text>-{formatTime(durationInMs - positionInMs)}</Text>
+          <Text style={styles.monospacedText}>
+            -{formatTime(durationInMs - positionInMs)}
+          </Text>
         )}
       </View>
       <View
@@ -96,3 +98,10 @@ export const PlayerControls = () => {
     </View>
   );
 };
+
+const styles = StyleSheet.create({
+  monospacedText: {
+    fontFamily: "Helvetica",
+    letterSpacing: 0.5,
+  },
+});


### PR DESCRIPTION
Removing custom styles on time markers to be consistent with the rest of the app

![IMG_4030](https://github.com/wavlake/mobile/assets/77257032/d9326894-4d87-4ead-96bc-c9805f839618)
