### PR TITLE
disable font scaling for top numbers

### DIFF
--- a/components/HomePageMusic.tsx
+++ b/components/HomePageMusic.tsx
@@ -39,6 +39,7 @@ const TopMusicRow = ({ trackList, track, index }: TopMusicRowProps) => {
         }}
       >
         <Text
+          allowFontScaling={false}
           style={{
             fontSize: 36,
             width: 48,


### PR DESCRIPTION
this fixes this bug https://appstoreconnect.apple.com/apps/6463653431/testflight/screenshots?appPlatform=IOS&preReleaseVersionId=4d50480b-f0ff-4b8f-8e6c-c6477ccdb225&sort=-timestamp

you can adjust the text size on your iPhone by going into Settings => Accessibility => Display & Text Size => Larger Text => move slider to the right