### PR TITLE
Swap music player library

### DIFF
--- a/app/(drawer)/(tabs)/(home)/index.tsx
+++ b/app/(drawer)/(tabs)/(home)/index.tsx
@@ -1,6 +1,50 @@
 import { PillTabView, Text, Center, HomePageMusic } from "@/components";
+import { useAuth } from "@/hooks";
+import TrackPlayer from "react-native-track-player";
 
 export default function HomePage() {
+  const { pubkey } = useAuth();
+
+  // TODO: remove this once testing if controls show up on lock screen
+  const handleTestMusicPlayerPress = async () => {
+    console.log(pubkey);
+    if (
+      pubkey !==
+      "3fa9305e2e7b099d6cc8ebecf76b51907c63bef8a09a6638e6e1ed5acd30a1a8"
+    ) {
+      return;
+    }
+    const tracks = [
+      {
+        url: "https://d12wklypp119aj.cloudfront.net/track/2b86228e-bc6c-4451-86c3-dae92d93ce81.mp3",
+        title: "Lying to you",
+        artist: "skrilla bobcat",
+        artwork:
+          "https://d12wklypp119aj.cloudfront.net/image/17d068f9-4d29-4165-b614-08a82281ab80.jpg",
+        duration: 138,
+      },
+      {
+        url: "https://d12wklypp119aj.cloudfront.net/track/b3fd6450-b908-4874-a279-6aca4d51128d.mp3",
+        title: "Paperboy ft. skrilla bobcat",
+        artist: "skrilla bobcat",
+        artwork:
+          "https://d12wklypp119aj.cloudfront.net/image/ef9276d1-c028-4223-b04e-636364c2dc60.jpg",
+        duration: 216,
+      },
+      {
+        url: "https://d12wklypp119aj.cloudfront.net/track/3bfb9c1c-b929-42f8-8832-6f6adc01017e.mp3",
+        title: "Beefsteak and Tradwives",
+        artist: "Bobby Shell",
+        artwork:
+          "https://d12wklypp119aj.cloudfront.net/image/fb3d61d3-866a-4699-a6e9-b7edfdc11069.jpg",
+        duration: 177,
+      },
+    ];
+
+    await TrackPlayer.add(tracks);
+    TrackPlayer.play().catch(console.error);
+  };
+
   return (
     <PillTabView searchShown>
       <PillTabView.Item style={{ width: "100%" }}>
@@ -8,7 +52,9 @@ export default function HomePage() {
       </PillTabView.Item>
       <PillTabView.Item style={{ width: "100%" }}>
         <Center>
-          <Text>New and trending shows coming soon</Text>
+          <Text onPress={handleTestMusicPlayerPress}>
+            New and trending shows coming soon
+          </Text>
         </Center>
       </PillTabView.Item>
     </PillTabView>

--- a/app/(drawer)/(tabs)/(home)/index.tsx
+++ b/app/(drawer)/(tabs)/(home)/index.tsx
@@ -1,50 +1,6 @@
 import { PillTabView, Text, Center, HomePageMusic } from "@/components";
-import { useAuth } from "@/hooks";
-import TrackPlayer from "react-native-track-player";
 
 export default function HomePage() {
-  const { pubkey } = useAuth();
-
-  // TODO: remove this once testing if controls show up on lock screen
-  const handleTestMusicPlayerPress = async () => {
-    console.log(pubkey);
-    if (
-      pubkey !==
-      "3fa9305e2e7b099d6cc8ebecf76b51907c63bef8a09a6638e6e1ed5acd30a1a8"
-    ) {
-      return;
-    }
-    const tracks = [
-      {
-        url: "https://d12wklypp119aj.cloudfront.net/track/2b86228e-bc6c-4451-86c3-dae92d93ce81.mp3",
-        title: "Lying to you",
-        artist: "skrilla bobcat",
-        artwork:
-          "https://d12wklypp119aj.cloudfront.net/image/17d068f9-4d29-4165-b614-08a82281ab80.jpg",
-        duration: 138,
-      },
-      {
-        url: "https://d12wklypp119aj.cloudfront.net/track/b3fd6450-b908-4874-a279-6aca4d51128d.mp3",
-        title: "Paperboy ft. skrilla bobcat",
-        artist: "skrilla bobcat",
-        artwork:
-          "https://d12wklypp119aj.cloudfront.net/image/ef9276d1-c028-4223-b04e-636364c2dc60.jpg",
-        duration: 216,
-      },
-      {
-        url: "https://d12wklypp119aj.cloudfront.net/track/3bfb9c1c-b929-42f8-8832-6f6adc01017e.mp3",
-        title: "Beefsteak and Tradwives",
-        artist: "Bobby Shell",
-        artwork:
-          "https://d12wklypp119aj.cloudfront.net/image/fb3d61d3-866a-4699-a6e9-b7edfdc11069.jpg",
-        duration: 177,
-      },
-    ];
-
-    await TrackPlayer.add(tracks);
-    TrackPlayer.play().catch(console.error);
-  };
-
   return (
     <PillTabView searchShown>
       <PillTabView.Item style={{ width: "100%" }}>
@@ -52,9 +8,7 @@ export default function HomePage() {
       </PillTabView.Item>
       <PillTabView.Item style={{ width: "100%" }}>
         <Center>
-          <Text onPress={handleTestMusicPlayerPress}>
-            New and trending shows coming soon
-          </Text>
+          <Text>New and trending shows coming soon</Text>
         </Center>
       </PillTabView.Item>
     </PillTabView>

--- a/app/(drawer)/(tabs)/(home)/music/discover.tsx
+++ b/app/(drawer)/(tabs)/(home)/music/discover.tsx
@@ -1,15 +1,8 @@
-import { TrackList, useMusicPlayer } from "@/components";
+import { TrackList } from "@/components";
 import { useNewMusic } from "@/hooks";
 
 export default function DiscoverPage() {
   const { data = [] } = useNewMusic();
-  const { loadTrackList } = useMusicPlayer();
 
-  return (
-    <TrackList
-      data={data}
-      playerTitle="New music"
-      loadTrackList={loadTrackList}
-    />
-  );
+  return <TrackList data={data} playerTitle="New music" />;
 }

--- a/app/(drawer)/(tabs)/_layout.tsx
+++ b/app/(drawer)/(tabs)/_layout.tsx
@@ -14,7 +14,6 @@ import {
 } from "@/components";
 import {
   cacheIsFirstAppLaunch,
-  formatTrackListForMusicPlayer,
   getIsFirstAppLaunch,
   getRandomMusic,
 } from "@/utils";
@@ -24,7 +23,7 @@ import { useEffect } from "react";
 export default function TabLayout() {
   const pathname = usePathname();
   const { colors } = useTheme();
-  const { loadTrackList, clear } = useMusicPlayer();
+  const { loadTrackList } = useMusicPlayer();
   const tabsBarHeight = 88;
   const { pubkey } = useAuth();
   const router = useRouter();
@@ -91,12 +90,9 @@ export default function TabLayout() {
             }}
             listeners={() => ({
               tabPress: async () => {
-                await clear();
-
-                const randomMusic = await getRandomMusic();
-
                 await loadTrackList({
-                  trackList: formatTrackListForMusicPlayer(randomMusic),
+                  trackList: await getRandomMusic(),
+                  trackListId: "radio",
                   playerTitle: "Radio",
                 });
               },

--- a/app/(drawer)/(tabs)/_layout.tsx
+++ b/app/(drawer)/(tabs)/_layout.tsx
@@ -23,7 +23,7 @@ import { useEffect } from "react";
 export default function TabLayout() {
   const pathname = usePathname();
   const { colors } = useTheme();
-  const { loadTrackList } = useMusicPlayer();
+  const { loadTrackList, reset } = useMusicPlayer();
   const tabsBarHeight = 88;
   const { pubkey } = useAuth();
   const router = useRouter();
@@ -90,6 +90,7 @@ export default function TabLayout() {
             }}
             listeners={() => ({
               tabPress: async () => {
+                await reset();
                 await loadTrackList({
                   trackList: await getRandomMusic(),
                   trackListId: "radio",

--- a/app/(drawer)/(tabs)/library/music/recent-songs.tsx
+++ b/app/(drawer)/(tabs)/library/music/recent-songs.tsx
@@ -1,14 +1,7 @@
-import { TrackList, useMusicPlayer } from "@/components";
+import { TrackList } from "@/components";
 import { useLibraryTracks } from "@/hooks";
 export default function RecentSongsPage() {
   const { data: tracks = [] } = useLibraryTracks();
-  const { loadTrackList } = useMusicPlayer();
 
-  return (
-    <TrackList
-      data={tracks}
-      playerTitle="Recent songs"
-      loadTrackList={loadTrackList}
-    />
-  );
+  return <TrackList data={tracks} playerTitle="Recent songs" />;
 }

--- a/app/(drawer)/(tabs)/library/music/songs.tsx
+++ b/app/(drawer)/(tabs)/library/music/songs.tsx
@@ -1,7 +1,5 @@
-import { LibrarySongsPage, useMusicPlayer } from "@/components";
+import { LibrarySongsPage } from "@/components";
 
 export default function SongsPage() {
-  const { loadTrackList } = useMusicPlayer();
-
-  return <LibrarySongsPage loadTrackList={loadTrackList} />;
+  return <LibrarySongsPage />;
 }

--- a/app/(drawer)/(tabs)/search/genre/[genreId].tsx
+++ b/app/(drawer)/(tabs)/search/genre/[genreId].tsx
@@ -1,4 +1,4 @@
-import { TrackList, useMusicPlayer } from "@/components";
+import { TrackList } from "@/components";
 import { getRandomGenreTracks } from "@/utils";
 import { useLocalSearchParams } from "expo-router";
 import { useQuery } from "@tanstack/react-query";
@@ -9,13 +9,6 @@ export default function GenrePage() {
     queryKey: ["genre", genreId],
     queryFn: () => getRandomGenreTracks(genreId as string),
   });
-  const { loadTrackList } = useMusicPlayer();
 
-  return (
-    <TrackList
-      data={data}
-      playerTitle={name as string}
-      loadTrackList={loadTrackList}
-    />
-  );
+  return <TrackList data={data} playerTitle={name as string} />;
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -17,7 +17,6 @@ import {
 import { MusicPlayerProvider } from "@/components";
 import { AppState, Platform, AppStateStatus, View } from "react-native";
 import { RootSiblingParent } from "react-native-root-siblings";
-import { useNostrRelayList } from "@/hooks";
 import TrackPlayer, { Capability } from "react-native-track-player";
 import { musicService } from "@/services";
 
@@ -28,52 +27,6 @@ export { ErrorBoundary } from "expo-router";
 SplashScreen.preventAutoHideAsync();
 
 const queryClient = new QueryClient();
-
-const AppContent = () => {
-  const { writeRelayList } = useNostrRelayList();
-
-  return (
-    <MusicPlayerProvider writeRelayList={writeRelayList}>
-      <RootSiblingParent>
-        <View style={{ flex: 1, backgroundColor: "black" }}>
-          <Stack
-            screenOptions={{
-              headerStyle: {
-                backgroundColor: "black",
-              },
-              headerShadowVisible: false,
-              headerTintColor: "white",
-              headerBackTitleVisible: false,
-            }}
-          >
-            <Stack.Screen name="(drawer)" options={{ headerShown: false }} />
-            <Stack.Screen
-              name="auth"
-              options={{
-                headerShown: false,
-                gestureEnabled: false,
-                gestureDirection: "vertical",
-              }}
-            />
-            <Stack.Screen
-              name="zap"
-              options={{
-                headerShown: false,
-                gestureEnabled: false,
-                gestureDirection: "vertical",
-              }}
-            />
-            <Stack.Screen name="profile" options={{ headerTitle: "Profile" }} />
-            <Stack.Screen
-              name="settings"
-              options={{ headerTitle: "Settings" }}
-            />
-          </Stack>
-        </View>
-      </RootSiblingParent>
-    </MusicPlayerProvider>
-  );
-};
 
 export default function Layout() {
   const [loaded, error] = useFonts({
@@ -132,7 +85,51 @@ export default function Layout() {
   return loaded ? (
     <ThemeProvider value={DarkTheme}>
       <QueryClientProvider client={queryClient}>
-        <AppContent />
+        <MusicPlayerProvider>
+          <RootSiblingParent>
+            <View style={{ flex: 1, backgroundColor: "black" }}>
+              <Stack
+                screenOptions={{
+                  headerStyle: {
+                    backgroundColor: "black",
+                  },
+                  headerShadowVisible: false,
+                  headerTintColor: "white",
+                  headerBackTitleVisible: false,
+                }}
+              >
+                <Stack.Screen
+                  name="(drawer)"
+                  options={{ headerShown: false }}
+                />
+                <Stack.Screen
+                  name="auth"
+                  options={{
+                    headerShown: false,
+                    gestureEnabled: false,
+                    gestureDirection: "vertical",
+                  }}
+                />
+                <Stack.Screen
+                  name="zap"
+                  options={{
+                    headerShown: false,
+                    gestureEnabled: false,
+                    gestureDirection: "vertical",
+                  }}
+                />
+                <Stack.Screen
+                  name="profile"
+                  options={{ headerTitle: "Profile" }}
+                />
+                <Stack.Screen
+                  name="settings"
+                  options={{ headerTitle: "Settings" }}
+                />
+              </Stack>
+            </View>
+          </RootSiblingParent>
+        </MusicPlayerProvider>
       </QueryClientProvider>
     </ThemeProvider>
   ) : null;

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,3 +1,6 @@
+// https://docs.expo.dev/develop/development-builds/use-development-builds/
+import "expo-dev-client";
+
 import { useEffect } from "react";
 import { Stack, SplashScreen } from "expo-router";
 import { DarkTheme, ThemeProvider } from "@react-navigation/native";
@@ -15,6 +18,8 @@ import { MusicPlayerProvider } from "@/components";
 import { AppState, Platform, AppStateStatus, View } from "react-native";
 import { RootSiblingParent } from "react-native-root-siblings";
 import { useNostrRelayList } from "@/hooks";
+import TrackPlayer from "react-native-track-player";
+import { musicService } from "@/services";
 
 // Catch any errors thrown by the Layout component.
 export { ErrorBoundary } from "expo-router";
@@ -88,6 +93,11 @@ export default function Layout() {
       }, 2000);
     }
   }, [loaded]);
+
+  useEffect(() => {
+    TrackPlayer.registerPlaybackService(() => musicService);
+    TrackPlayer.setupPlayer().catch(console.error);
+  }, []);
 
   const onAppStateChange = (status: AppStateStatus) => {
     if (Platform.OS !== "web") {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -18,7 +18,7 @@ import { MusicPlayerProvider } from "@/components";
 import { AppState, Platform, AppStateStatus, View } from "react-native";
 import { RootSiblingParent } from "react-native-root-siblings";
 import { useNostrRelayList } from "@/hooks";
-import TrackPlayer from "react-native-track-player";
+import TrackPlayer, { Capability } from "react-native-track-player";
 import { musicService } from "@/services";
 
 // Catch any errors thrown by the Layout component.
@@ -95,8 +95,26 @@ export default function Layout() {
   }, [loaded]);
 
   useEffect(() => {
-    TrackPlayer.registerPlaybackService(() => musicService);
-    TrackPlayer.setupPlayer().catch(console.error);
+    try {
+      TrackPlayer.registerPlaybackService(() => musicService);
+    } catch (error) {
+      console.log("error registering playback service", error);
+    }
+
+    TrackPlayer.setupPlayer().catch((error) => {
+      console.log("error setting up player", error);
+    });
+
+    TrackPlayer.updateOptions({
+      capabilities: [
+        Capability.Play,
+        Capability.Pause,
+        Capability.SkipToNext,
+        Capability.SkipToPrevious,
+      ],
+    }).catch((error) => {
+      console.log("error updating options", error);
+    });
   }, []);
 
   const onAppStateChange = (status: AppStateStatus) => {

--- a/components/AlbumOrArtistPageHeader.tsx
+++ b/components/AlbumOrArtistPageHeader.tsx
@@ -12,8 +12,9 @@ import {
   useIsAlbumInLibrary,
   useIsArtistInLibrary,
 } from "@/hooks";
-import { Album, Artist } from "@/utils";
+import { Album, Artist, togglePlayPause } from "@/utils";
 import { ArtistBanner } from "@/components/ArtistBanner";
+import { State, usePlaybackState } from "react-native-track-player";
 
 interface AlbumOrArtistPageHeaderProps {
   type: "album" | "artist";
@@ -32,10 +33,12 @@ export const AlbumOrArtistPageHeader = ({
   trackListTitle,
   onPlay,
 }: AlbumOrArtistPageHeaderProps) => {
-  const { currentTrackListId, status, togglePlayPause } = useMusicPlayer();
+  const { currentTrackListId } = useMusicPlayer();
+  const playbackState = usePlaybackState();
   const screenWidth = Dimensions.get("window").width;
   const isThisTrackListLoaded = currentTrackListId === trackListId;
-  const isThisTrackListPlaying = status === "playing" && isThisTrackListLoaded;
+  const isThisTrackListPlaying =
+    isThisTrackListLoaded && playbackState !== State.Paused;
   const isAlbum = type === "album";
   const isAlbumInLibrary = useIsAlbumInLibrary(trackListId);
   const addAlbumToLibraryMutation = useAddAlbumToLibrary();

--- a/components/AlbumPage.tsx
+++ b/components/AlbumPage.tsx
@@ -1,18 +1,9 @@
 import { useLocalSearchParams } from "expo-router";
 import { FlatList, View } from "react-native";
 import { useQuery } from "@tanstack/react-query";
-import {
-  Album,
-  formatTrackListForMusicPlayer,
-  getAlbum,
-  getAlbumTracks,
-} from "@/utils";
+import { Album, getAlbum, getAlbumTracks } from "@/utils";
 import { Text } from "@/components/Text";
-import {
-  LoadTrackList,
-  useMusicPlayer,
-} from "@/components/MusicPlayerProvider";
-import { memo } from "react";
+import { useMusicPlayer } from "@/components/MusicPlayerProvider";
 import { AlbumOrArtistPageHeader } from "@/components/AlbumOrArtistPageHeader";
 import { TrackRow } from "@/components/TrackRow";
 import { SectionHeader } from "@/components/SectionHeader";
@@ -30,11 +21,8 @@ const AlbumPageFooter = ({ album }: AlbumPageFooterProps) => {
   );
 };
 
-interface AlbumPageContentProps {
-  loadTrackList: LoadTrackList;
-}
-
-const AlbumPageContent = memo(({ loadTrackList }: AlbumPageContentProps) => {
+export const AlbumPage = () => {
+  const { loadTrackList } = useMusicPlayer();
   const { albumId } = useLocalSearchParams();
   const { data: album } = useQuery({
     queryKey: [albumId],
@@ -47,7 +35,7 @@ const AlbumPageContent = memo(({ loadTrackList }: AlbumPageContentProps) => {
   });
   const handleRowPress = async (index: number, playerTitle: string) => {
     await loadTrackList({
-      trackList: formatTrackListForMusicPlayer(tracks),
+      trackList: tracks,
       trackListId: albumId as string,
       startIndex: index,
       playerTitle,
@@ -98,10 +86,4 @@ const AlbumPageContent = memo(({ loadTrackList }: AlbumPageContentProps) => {
       style={{ paddingTop: 8 }}
     />
   );
-});
-
-export const AlbumPage = () => {
-  const { loadTrackList } = useMusicPlayer();
-
-  return <AlbumPageContent loadTrackList={loadTrackList} />;
 };

--- a/components/ArtistPage.tsx
+++ b/components/ArtistPage.tsx
@@ -1,6 +1,6 @@
 import { useLocalSearchParams } from "expo-router";
 import { useQuery } from "@tanstack/react-query";
-import { getArtist, formatTrackListForMusicPlayer } from "@/utils";
+import { getArtist } from "@/utils";
 import {
   ActivityIndicator,
   ScrollView,
@@ -9,10 +9,7 @@ import {
 } from "react-native";
 import { AlbumOrArtistPageHeader } from "@/components/AlbumOrArtistPageHeader";
 import { Center } from "@/components/Center";
-import {
-  LoadTrackList,
-  useMusicPlayer,
-} from "@/components/MusicPlayerProvider";
+import { useMusicPlayer } from "@/components/MusicPlayerProvider";
 import { FireIcon } from "@/components/FireIcon";
 import { brandColors } from "@/constants";
 import { SectionHeader } from "@/components/SectionHeader";
@@ -23,7 +20,7 @@ import { SatsEarned } from "@/components/SatsEarned";
 import { WebsiteIcon } from "@/components/WebsiteIcon";
 import * as Linking from "expo-linking";
 import { useTheme } from "@react-navigation/native";
-import { ElementType, memo } from "react";
+import { ElementType } from "react";
 import { TwitterIcon } from "@/components/TwitterIcon";
 import { NostrIcon } from "@/components/NostrIcon";
 import { InstagramIcon } from "@/components/InstagramIcon";
@@ -46,11 +43,8 @@ const SocialIconLink = ({ url, Icon }: SocialIconLinkProps) => {
   );
 };
 
-interface ArtistPageContentProps {
-  loadTrackList: LoadTrackList;
-}
-
-const ArtistPageContent = memo(({ loadTrackList }: ArtistPageContentProps) => {
+export const ArtistPage = () => {
+  const { loadTrackList } = useMusicPlayer();
   const { artistId } = useLocalSearchParams();
   const { data: artist } = useQuery({
     queryKey: [artistId],
@@ -79,7 +73,7 @@ const ArtistPageContent = memo(({ loadTrackList }: ArtistPageContentProps) => {
     }
 
     await loadTrackList({
-      trackList: formatTrackListForMusicPlayer(topTracks),
+      trackList: topTracks,
       trackListId: artistId as string,
       startIndex: index,
       playerTitle,
@@ -198,10 +192,4 @@ const ArtistPageContent = memo(({ loadTrackList }: ArtistPageContentProps) => {
       <ActivityIndicator />
     </Center>
   );
-});
-
-export const ArtistPage = () => {
-  const { loadTrackList } = useMusicPlayer();
-
-  return <ArtistPageContent loadTrackList={loadTrackList} />;
 };

--- a/components/FullSizeMusicPlayer/ArtworkCarousel.tsx
+++ b/components/FullSizeMusicPlayer/ArtworkCarousel.tsx
@@ -12,12 +12,17 @@ export const ArtworkCarousel = () => {
     () => (trackQueue ?? []).map((track) => track.artworkUrl),
     [trackQueue],
   );
+  const carouselSize = trackQueueArtworkUrls.length;
 
   useEffect(() => {
+    if (carouselSize === 0) {
+      return;
+    }
+
     artworkUrlListRef.current?.scrollToIndex({
       index: currentTrackIndex,
     });
-  }, [currentTrackIndex]);
+  }, [currentTrackIndex, carouselSize]);
 
   return (
     <FlatList

--- a/components/FullSizeMusicPlayer/ArtworkCarousel.tsx
+++ b/components/FullSizeMusicPlayer/ArtworkCarousel.tsx
@@ -7,9 +7,9 @@ export const ArtworkCarousel = () => {
   const artworkUrlListRef = useRef<FlatList>(null);
   const screenWidth = Dimensions.get("window").width;
   const padding = 24;
-  const { trackQueue, currentTrackIndex } = useMusicPlayer();
+  const { trackQueue, currentTrackIndex = 0 } = useMusicPlayer();
   const trackQueueArtworkUrls = useMemo(
-    () => trackQueue.map((track) => track.artworkUrl),
+    () => (trackQueue ?? []).map((track) => track.artworkUrl),
     [trackQueue],
   );
 

--- a/components/FullSizeMusicPlayer/FullSizeMusicPlayer.tsx
+++ b/components/FullSizeMusicPlayer/FullSizeMusicPlayer.tsx
@@ -77,12 +77,8 @@ export const FullSizeMusicPlayer = () => {
     if (isTrackInLibrary) {
       deleteTrackFromLibraryMutation.mutate(trackId);
     } else {
-      // the duration, avatarUrl, and artistUrl are just needed to make TypeScript happy for the optimistic update
       addTrackToLibraryMutation.mutate({
-        ...currentTrack,
-        duration: currentTrack.durationInMs / 1000,
-        avatarUrl: currentTrack.avatarUrl ?? "",
-        artistUrl: "",
+        id: currentTrack.id,
       });
     }
   };

--- a/components/HomePageMusic.tsx
+++ b/components/HomePageMusic.tsx
@@ -1,6 +1,6 @@
 import { FlatList, TouchableOpacity, View } from "react-native";
 import { useQuery } from "@tanstack/react-query";
-import { formatTrackListForMusicPlayer, getTopMusic, Track } from "@/utils";
+import { getTopMusic, Track } from "@/utils";
 import { NewMusicSection } from "@/components/NewMusicSection";
 import { FireIcon } from "@/components/FireIcon";
 import { brandColors } from "@/constants";
@@ -22,7 +22,8 @@ const TopMusicRow = ({ trackList, track, index }: TopMusicRowProps) => {
   const { height } = useMiniMusicPlayer();
   const handleRowPress = async (index: number) => {
     await loadTrackList({
-      trackList: formatTrackListForMusicPlayer(trackList),
+      trackList: trackList,
+      trackListId: "trending",
       startIndex: index,
       playerTitle: "Trending",
     });

--- a/components/LibraryRecentSongsSection.tsx
+++ b/components/LibraryRecentSongsSection.tsx
@@ -1,43 +1,36 @@
 import { View } from "react-native";
 import { useLibraryTracks } from "@/hooks";
-import { formatTrackListForMusicPlayer } from "@/utils";
-import { LoadTrackList } from "@/components/MusicPlayerProvider";
+import { useMusicPlayer } from "@/components/MusicPlayerProvider";
 import { HorizontalArtworkRow } from "@/components/HorizontalArtworkRow";
 import { PlayButtonSectionHeader } from "@/components/PlayButtonSectionHeader";
-import { memo } from "react";
 
-interface LibraryRecentSongsProps {
-  loadTrackList: LoadTrackList;
-}
+export const LibraryRecentSongsSection = () => {
+  const { data: tracks = [] } = useLibraryTracks();
+  const { loadTrackList } = useMusicPlayer();
+  const trackListId = "recent-songs";
+  const playerTitle = "Recent Songs";
 
-export const LibraryRecentSongsSection = memo(
-  ({ loadTrackList }: LibraryRecentSongsProps) => {
-    const { data: tracks = [] } = useLibraryTracks();
-    const trackListId = "recent-songs";
-    const playerTitle = "Recent Songs";
+  const handleTrackPress = async (index: number) => {
+    await loadTrackList({
+      trackList: tracks,
+      trackListId,
+      startIndex: index,
+      playerTitle,
+    });
+  };
 
-    const handleTrackPress = async (index: number) => {
-      await loadTrackList({
-        trackList: formatTrackListForMusicPlayer(tracks),
-        trackListId,
-        startIndex: index,
-        playerTitle,
-      });
-    };
-
-    return (
-      <View>
-        <PlayButtonSectionHeader
-          title={playerTitle}
-          trackListId={trackListId}
-          tracks={tracks}
-          rightNavHref={{
-            pathname: "/library/music/recent-songs",
-            params: { headerTitle: playerTitle, includeBackButton: true },
-          }}
-        />
-        <HorizontalArtworkRow items={tracks} onPress={handleTrackPress} />
-      </View>
-    );
-  },
-);
+  return (
+    <View>
+      <PlayButtonSectionHeader
+        title={playerTitle}
+        trackListId={trackListId}
+        tracks={tracks}
+        rightNavHref={{
+          pathname: "/library/music/recent-songs",
+          params: { headerTitle: playerTitle, includeBackButton: true },
+        }}
+      />
+      <HorizontalArtworkRow items={tracks} onPress={handleTrackPress} />
+    </View>
+  );
+};

--- a/components/LibrarySongsPage.tsx
+++ b/components/LibrarySongsPage.tsx
@@ -3,93 +3,86 @@ import { useLibraryTracks } from "@/hooks";
 import { FlatList, View } from "react-native";
 import { PlayButtonSectionHeader } from "@/components/PlayButtonSectionHeader";
 import { TrackRow } from "@/components/TrackRow";
-import { formatTrackListForMusicPlayer } from "@/utils";
-import { LoadTrackList } from "@/components/MusicPlayerProvider";
-import { memo, useMemo } from "react";
+import { useMusicPlayer } from "@/components/MusicPlayerProvider";
+import { useMemo } from "react";
 import { Center } from "@/components/Center";
 import { Text } from "@/components/Text";
 import { useMiniMusicPlayer } from "@/components/MiniMusicPlayerProvider";
+export const LibrarySongsPage = () => {
+  const { loadTrackList } = useMusicPlayer();
+  const { data: tracks = [] } = useLibraryTracks();
+  const sortedTracks = useMemo(
+    () =>
+      [...tracks].sort((a, b) => {
+        const trackTitleA = a.title.toLowerCase();
+        const trackTitleB = b.title.toLowerCase();
+        const trackArtistA = a.artist.toLowerCase();
+        const trackArtistB = b.artist.toLowerCase();
 
-interface LibrarySongsPageProps {
-  loadTrackList: LoadTrackList;
-}
+        if (
+          trackTitleA < trackTitleB ||
+          (trackTitleA === trackTitleB && trackArtistA < trackArtistB)
+        ) {
+          return -1;
+        }
 
-export const LibrarySongsPage = memo(
-  ({ loadTrackList }: LibrarySongsPageProps) => {
-    const { data: tracks = [] } = useLibraryTracks();
-    const sortedTracks = useMemo(
-      () =>
-        [...tracks].sort((a, b) => {
-          const trackTitleA = a.title.toLowerCase();
-          const trackTitleB = b.title.toLowerCase();
-          const trackArtistA = a.artist.toLowerCase();
-          const trackArtistB = b.artist.toLowerCase();
+        if (
+          trackTitleA > trackTitleB ||
+          (trackTitleA === trackTitleB && trackArtistA > trackArtistB)
+        ) {
+          return 1;
+        }
 
-          if (
-            trackTitleA < trackTitleB ||
-            (trackTitleA === trackTitleB && trackArtistA < trackArtistB)
-          ) {
-            return -1;
-          }
+        return 0;
+      }),
+    [tracks],
+  );
+  const trackListId = "song-library";
+  const playerTitle = "Song Library";
+  const { height } = useMiniMusicPlayer();
+  const handleTrackPress = async (index: number) => {
+    await loadTrackList({
+      trackList: sortedTracks,
+      trackListId,
+      startIndex: index,
+      playerTitle,
+    });
+  };
 
-          if (
-            trackTitleA > trackTitleB ||
-            (trackTitleA === trackTitleB && trackArtistA > trackArtistB)
-          ) {
-            return 1;
-          }
+  return tracks.length > 0 ? (
+    <FlatList
+      data={sortedTracks}
+      ListHeaderComponent={() => (
+        <View>
+          <LibraryRecentSongsSection />
+          <PlayButtonSectionHeader
+            title={playerTitle}
+            trackListId={trackListId}
+            tracks={sortedTracks}
+          />
+        </View>
+      )}
+      renderItem={({ item, index }) => {
+        const isLastRow = index === sortedTracks.length - 1;
+        const marginBottom = isLastRow ? height + 16 : 16;
 
-          return 0;
-        }),
-      [tracks],
-    );
-    const trackListId = "song-library";
-    const playerTitle = "Song Library";
-    const { height } = useMiniMusicPlayer();
-    const handleTrackPress = async (index: number) => {
-      await loadTrackList({
-        trackList: formatTrackListForMusicPlayer(sortedTracks),
-        trackListId,
-        startIndex: index,
-        playerTitle,
-      });
-    };
-
-    return tracks.length > 0 ? (
-      <FlatList
-        data={sortedTracks}
-        ListHeaderComponent={() => (
-          <View>
-            <LibraryRecentSongsSection loadTrackList={loadTrackList} />
-            <PlayButtonSectionHeader
-              title={playerTitle}
-              trackListId={trackListId}
-              tracks={sortedTracks}
+        return (
+          <View style={{ marginBottom }}>
+            <TrackRow
+              track={item}
+              descriptor={item.artist}
+              onPress={() => handleTrackPress(index)}
+              willDisplaySatsEarned={false}
+              willDisplayLikeButton={false}
             />
           </View>
-        )}
-        renderItem={({ item, index }) => {
-          const isLastRow = index === sortedTracks.length - 1;
-          const marginBottom = isLastRow ? height + 16 : 16;
-
-          return (
-            <View style={{ marginBottom }}>
-              <TrackRow
-                track={item}
-                descriptor={item.artist}
-                onPress={() => handleTrackPress(index)}
-                willDisplaySatsEarned={false}
-                willDisplayLikeButton={false}
-              />
-            </View>
-          );
-        }}
-        keyExtractor={(item) => item.id}
-      />
-    ) : (
-      <Center>
-        <Text>No songs in your library yet.</Text>
-      </Center>
-    );
-  },
-);
+        );
+      }}
+      keyExtractor={(item) => item.id}
+    />
+  ) : (
+    <Center>
+      <Text>No songs in your library yet.</Text>
+    </Center>
+  );
+};

--- a/components/MiniMusicPlayer.tsx
+++ b/components/MiniMusicPlayer.tsx
@@ -1,11 +1,17 @@
-import { View, Pressable } from "react-native";
+import { Pressable, View } from "react-native";
 import { SquareArtwork } from "./SquareArtwork";
-import { useMusicPlayer } from "./MusicPlayerProvider";
 import { useTheme } from "@react-navigation/native";
 import { useRouter } from "expo-router";
 import Ionicons from "@expo/vector-icons/Ionicons";
 import { MarqueeText } from "@/components/MarqueeText";
 import { useGetArtistOrAlbumBasePathname } from "@/hooks/useGetArtistOrAlbumBasePathname";
+import {
+  State,
+  usePlaybackState,
+  useProgress,
+} from "react-native-track-player";
+import { togglePlayPause } from "@/utils";
+import { useMusicPlayer } from "@/components/MusicPlayerProvider";
 
 interface PlayerButtonProps {
   onPress: () => void;
@@ -35,14 +41,18 @@ export const MiniMusicPlayer = () => {
   const artistOrAlbumBasePathname = useGetArtistOrAlbumBasePathname();
   const router = useRouter();
   const { colors } = useTheme();
-  const { status, positionInMs, togglePlayPause, clear, currentTrack } =
-    useMusicPlayer();
-  const { artworkUrl, title, artist, durationInMs } = currentTrack || {};
-  const progressBarWidth = durationInMs
-    ? (positionInMs / durationInMs) * 100 || 0
-    : 0;
+  const { position, duration } = useProgress();
+  const playbackState = usePlaybackState();
+  const { currentTrack, reset, isSwitchingTrackList } = useMusicPlayer();
+  const willShowPlayer = currentTrack !== null;
+  const willDisplayPauseButton =
+    playbackState !== State.Paused || isSwitchingTrackList;
+  const willDisplayPlayButton =
+    playbackState === State.Paused && !isSwitchingTrackList;
+  const { artworkUrl, title, artist } = currentTrack || {};
+  const progressBarWidth = duration ? (position / duration) * 100 : 0;
 
-  return currentTrack ? (
+  return willShowPlayer ? (
     <Pressable
       onPress={() =>
         router.push({
@@ -80,19 +90,19 @@ export const MiniMusicPlayer = () => {
                 gap: 10,
               }}
             >
-              {status === "playing" && (
+              {willDisplayPauseButton && (
                 <PlayerButton
                   onPress={togglePlayPause}
                   iconName="ios-pause-sharp"
                 />
               )}
-              {status === "paused" && (
+              {willDisplayPlayButton && (
                 <PlayerButton
                   onPress={togglePlayPause}
                   iconName="ios-play-sharp"
                 />
               )}
-              <PlayerButton onPress={clear} iconName="ios-close-sharp" />
+              <PlayerButton onPress={reset} iconName="ios-close-sharp" />
             </View>
           </View>
         </View>

--- a/components/MiniMusicPlayerProvider.tsx
+++ b/components/MiniMusicPlayerProvider.tsx
@@ -9,8 +9,9 @@ const MiniMusicPlayerContext =
   createContext<MiniMusicPlayerContextProps | null>(null);
 
 export const MiniMusicPlayerProvider = ({ children }: PropsWithChildren) => {
-  const { trackQueue } = useMusicPlayer();
-  const height = trackQueue.length > 0 ? 70 : 0;
+  const { currentTrack } = useMusicPlayer();
+  const willShowPlayer = currentTrack !== null;
+  const height = willShowPlayer ? 70 : 0;
   const value = useMemo(() => ({ height }), [height]);
 
   return (

--- a/components/NewMusicSection.tsx
+++ b/components/NewMusicSection.tsx
@@ -4,7 +4,6 @@ import { SectionHeader } from "./SectionHeader";
 import { View } from "react-native";
 import { useMusicPlayer } from "./MusicPlayerProvider";
 import { useNewMusic } from "@/hooks";
-import { formatTrackListForMusicPlayer } from "@/utils";
 import { HorizontalArtworkRow } from "@/components/HorizontalArtworkRow";
 
 export const NewMusicSection = () => {
@@ -12,7 +11,8 @@ export const NewMusicSection = () => {
   const { loadTrackList } = useMusicPlayer();
   const handleRowPress = async (index: number) => {
     await loadTrackList({
-      trackList: formatTrackListForMusicPlayer(data),
+      trackList: data,
+      trackListId: "new-music",
       startIndex: index,
       playerTitle: "New music",
     });

--- a/components/PlayButtonSectionHeader.tsx
+++ b/components/PlayButtonSectionHeader.tsx
@@ -2,7 +2,8 @@ import { PlayPauseTrackButton } from "@/components/PlayPauseTrackButton";
 import { brandColors } from "@/constants";
 import { SectionHeader } from "@/components/SectionHeader";
 import { useMusicPlayer } from "@/components/MusicPlayerProvider";
-import { formatTrackListForMusicPlayer, Track } from "@/utils";
+import { togglePlayPause, Track } from "@/utils";
+import { State, usePlaybackState } from "react-native-track-player";
 
 interface PlayButtonSectionHeaderProps {
   title: string;
@@ -17,13 +18,14 @@ export const PlayButtonSectionHeader = ({
   tracks,
   rightNavHref,
 }: PlayButtonSectionHeaderProps) => {
-  const { loadTrackList, status, currentTrackListId, togglePlayPause } =
-    useMusicPlayer();
+  const { loadTrackList, currentTrackListId } = useMusicPlayer();
+  const playbackState = usePlaybackState();
   const isThisTrackListLoaded = currentTrackListId === trackListId;
-  const isThisTrackListPlaying = status === "playing" && isThisTrackListLoaded;
+  const isThisTrackListPlaying =
+    playbackState !== State.Paused && isThisTrackListLoaded;
   const handleTrackPress = async (index: number) => {
     await loadTrackList({
-      trackList: formatTrackListForMusicPlayer(tracks),
+      trackList: tracks,
       trackListId,
       startIndex: index,
       playerTitle: title,

--- a/components/SearchResults.tsx
+++ b/components/SearchResults.tsx
@@ -56,9 +56,10 @@ const SearchResultRow = ({
             avatarUrl,
             albumId,
             albumTitle,
-            durationInMs: duration * 1000,
+            duration,
           },
         ],
+        trackListId: "search-result-track",
       });
     }
 

--- a/components/TrackList.tsx
+++ b/components/TrackList.tsx
@@ -1,67 +1,65 @@
 import { FlatList, TouchableOpacity, View } from "react-native";
-import { LoadTrackList } from "@/components/MusicPlayerProvider";
-import { formatTrackListForMusicPlayer, Track } from "@/utils";
+import { useMusicPlayer } from "@/components/MusicPlayerProvider";
+import { Track } from "@/utils";
 import { SquareArtwork } from "@/components/SquareArtwork";
 import { Text } from "@/components/Text";
 import { useMiniMusicPlayer } from "@/components/MiniMusicPlayerProvider";
-import { memo } from "react";
 
 interface TrackListProps {
   data: Track[];
   playerTitle: string;
-  loadTrackList: LoadTrackList;
 }
 
-export const TrackList = memo(
-  ({ data, playerTitle, loadTrackList }: TrackListProps) => {
-    const { height } = useMiniMusicPlayer();
+export const TrackList = ({ data, playerTitle }: TrackListProps) => {
+  const { height } = useMiniMusicPlayer();
+  const { loadTrackList } = useMusicPlayer();
 
-    const handleRowPress = async (index: number) => {
-      await loadTrackList({
-        trackList: formatTrackListForMusicPlayer(data),
-        startIndex: index,
-        playerTitle,
-      });
-    };
+  const handleRowPress = async (index: number) => {
+    await loadTrackList({
+      trackList: data,
+      trackListId: playerTitle,
+      startIndex: index,
+      playerTitle,
+    });
+  };
 
-    return (
-      <View style={{ height: "100%", paddingTop: 16 }}>
-        <FlatList
-          data={data}
-          renderItem={({ item, index }) => {
-            const { artworkUrl, title, artist } = item;
-            const isLastRow = index === data.length - 1;
-            const marginBottom = isLastRow ? height + 16 : 16;
+  return (
+    <View style={{ height: "100%", paddingTop: 16 }}>
+      <FlatList
+        data={data}
+        renderItem={({ item, index }) => {
+          const { artworkUrl, title, artist } = item;
+          const isLastRow = index === data.length - 1;
+          const marginBottom = isLastRow ? height + 16 : 16;
 
-            return (
-              <TouchableOpacity onPress={() => handleRowPress(index)}>
-                <View
-                  style={{
-                    flexDirection: "row",
-                    marginBottom,
-                  }}
-                >
-                  <SquareArtwork size={124} url={artworkUrl} />
-                  <View style={{ marginLeft: 10, flex: 1 }}>
-                    <Text
-                      style={{
-                        fontSize: 18,
-                      }}
-                      numberOfLines={3}
-                      bold
-                    >
-                      {title}
-                    </Text>
-                    <Text>{artist}</Text>
-                  </View>
+          return (
+            <TouchableOpacity onPress={() => handleRowPress(index)}>
+              <View
+                style={{
+                  flexDirection: "row",
+                  marginBottom,
+                }}
+              >
+                <SquareArtwork size={124} url={artworkUrl} />
+                <View style={{ marginLeft: 10, flex: 1 }}>
+                  <Text
+                    style={{
+                      fontSize: 18,
+                    }}
+                    numberOfLines={3}
+                    bold
+                  >
+                    {title}
+                  </Text>
+                  <Text>{artist}</Text>
                 </View>
-              </TouchableOpacity>
-            );
-          }}
-          keyExtractor={(item) => item.id}
-          scrollEnabled
-        />
-      </View>
-    );
-  },
-);
+              </View>
+            </TouchableOpacity>
+          );
+        }}
+        keyExtractor={(item) => item.id}
+        scrollEnabled
+      />
+    </View>
+  );
+};

--- a/eas.json
+++ b/eas.json
@@ -25,7 +25,8 @@
         "EXPO_PUBLIC_WAVLAKE_API_URL": "https://catalog-staging-dot-wavlake-alpha.uc.r.appspot.com/v1"
       },
       "developmentClient": true,
-      "distribution": "internal"
+      "distribution": "internal",
+      "channel": "development"
     }
   }
 }

--- a/eas.json
+++ b/eas.json
@@ -19,6 +19,13 @@
       },
       "distribution": "internal",
       "channel": "preview"
+    },
+    "development": {
+      "env": {
+        "EXPO_PUBLIC_WAVLAKE_API_URL": "https://catalog-staging-dot-wavlake-alpha.uc.r.appspot.com/v1"
+      },
+      "developmentClient": true,
+      "distribution": "internal"
     }
   }
 }

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -1,22 +1,11 @@
 import {
   decodeNsec,
-  getPublicKey,
-  getSeckey,
   saveSeckey,
   deleteSeckey,
+  getPubkeyFromCachedSeckey,
 } from "@/utils";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigation } from "expo-router";
-
-const getPubkeyFromCachedSeckey = async () => {
-  try {
-    const seckey = await getSeckey();
-
-    return seckey ? getPublicKey(seckey) : "";
-  } catch {
-    return "";
-  }
-};
 
 export const useAuth = () => {
   const navigation = useNavigation();

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "expo-av": "~13.4.1",
         "expo-clipboard": "~4.3.1",
         "expo-constants": "~14.4.2",
+        "expo-dev-client": "~2.4.11",
         "expo-font": "~11.4.0",
         "expo-image": "~1.3.4",
         "expo-linking": "~5.0.2",
@@ -42,7 +43,8 @@
         "react-native-safe-area-context": "4.6.3",
         "react-native-screens": "~3.22.0",
         "react-native-svg": "13.9.0",
-        "react-native-text-ticker": "^1.14.0"
+        "react-native-text-ticker": "^1.14.0",
+        "react-native-track-player": "^3.2.0"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0",
@@ -9926,6 +9928,114 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-dev-client": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-2.4.11.tgz",
+      "integrity": "sha512-A7aKQZeEYG0YJ51GnjOFkMNe118jD1cbU+v5iM3E+H1Co5aVtnlGZWcv8Dtw3uGuWxRgbWGds5TGNbcDmJ1hDg==",
+      "dependencies": {
+        "expo-dev-launcher": "2.4.13",
+        "expo-dev-menu": "3.2.1",
+        "expo-dev-menu-interface": "1.3.0",
+        "expo-manifests": "~0.7.0",
+        "expo-updates-interface": "~0.10.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-launcher": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/expo-dev-launcher/-/expo-dev-launcher-2.4.13.tgz",
+      "integrity": "sha512-afszaREyGnhWJMmcOuDGs83r0UWeRvZrOHlKQxxst/UhAeFQqlDmkEjwtDWfTUy7BoXuuw2CuQtUFH+vTyjEGA==",
+      "dependencies": {
+        "expo-dev-menu": "3.2.1",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.3"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-launcher/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/expo-dev-launcher/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/expo-dev-launcher/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/expo-dev-menu": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu/-/expo-dev-menu-3.2.1.tgz",
+      "integrity": "sha512-SxH/ZUIYZliMBjJTpiECVSDkP7e81mbGNLH8ZD69iCAfLeH7P1OPXFycEdcvN33I7tVqzFgARGLK/W/8JV+U9w==",
+      "dependencies": {
+        "expo-dev-menu-interface": "1.3.0",
+        "semver": "^7.5.3"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-menu-interface": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu-interface/-/expo-dev-menu-interface-1.3.0.tgz",
+      "integrity": "sha512-WtRP7trQ2lizJJTTFXUSGGn1deIeHaYej0sUynvu/uC69VrSP4EeSnYOxbmEO29kuT/MsQBMGu0P/AkMQOqCOg==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-menu/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/expo-dev-menu/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/expo-dev-menu/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
     "node_modules/expo-eas-client": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/expo-eas-client/-/expo-eas-client-0.6.0.tgz",
@@ -15584,6 +15694,21 @@
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/react-native-text-ticker/-/react-native-text-ticker-1.14.0.tgz",
       "integrity": "sha512-8TNGTcW43dfnCqIuXVA7F1Ny8SKGrw0pIrNS5nM7eda+6AsuPTZh3JQ2CwmSRYfsrlnS4QFrpyo5ykpI8nvtCw=="
+    },
+    "node_modules/react-native-track-player": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-native-track-player/-/react-native-track-player-3.2.0.tgz",
+      "integrity": "sha512-svv6TOgU/quFV1aajG5PskVhgFG0wHQtO+aYs6cIH0D27ckzN8WVoC3jI94m1CVaSgLMw48P911csYuD2fIcqA==",
+      "peerDependencies": {
+        "react": ">=16.8.6",
+        "react-native": ">=0.60.0-rc.2",
+        "react-native-windows": ">=0.63.0"
+      },
+      "peerDependenciesMeta": {
+        "react-native-windows": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-native-vector-icons": {
       "version": "10.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
     "react-native-safe-area-context": "4.6.3",
     "react-native-screens": "~3.22.0",
     "react-native-svg": "13.9.0",
-    "react-native-text-ticker": "^1.14.0"
+    "react-native-text-ticker": "^1.14.0",
+    "react-native-track-player": "^3.2.0",
+    "expo-dev-client": "~2.4.11"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/services/index.ts
+++ b/services/index.ts
@@ -1,0 +1,1 @@
+export * from "./musicService";

--- a/services/musicService.ts
+++ b/services/musicService.ts
@@ -1,0 +1,23 @@
+import TrackPlayer, { Event } from "react-native-track-player";
+
+export const musicService = async () => {
+  TrackPlayer.addEventListener(Event.RemotePlay, () => {
+    console.log("play");
+    TrackPlayer.play();
+  });
+
+  TrackPlayer.addEventListener(Event.RemotePause, () => {
+    console.log("pause");
+    TrackPlayer.pause();
+  });
+
+  TrackPlayer.addEventListener(Event.RemotePrevious, () => {
+    console.log("previous");
+    TrackPlayer.skipToPrevious();
+  });
+
+  TrackPlayer.addEventListener(Event.RemoteNext, () => {
+    console.log("next");
+    TrackPlayer.skipToNext();
+  });
+};

--- a/services/musicService.ts
+++ b/services/musicService.ts
@@ -1,23 +1,20 @@
 import TrackPlayer, { Event } from "react-native-track-player";
+import { skipToPrevious } from "@/utils";
 
 export const musicService = async () => {
   TrackPlayer.addEventListener(Event.RemotePlay, () => {
-    console.log("play");
     TrackPlayer.play();
   });
 
   TrackPlayer.addEventListener(Event.RemotePause, () => {
-    console.log("pause");
     TrackPlayer.pause();
   });
 
   TrackPlayer.addEventListener(Event.RemotePrevious, () => {
-    console.log("previous");
-    TrackPlayer.skipToPrevious();
+    skipToPrevious();
   });
 
   TrackPlayer.addEventListener(Event.RemoteNext, () => {
-    console.log("next");
     TrackPlayer.skipToNext();
   });
 };

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -6,7 +6,7 @@ export interface Track {
   title: string;
   artistId: string;
   artist: string;
-  artistUrl: string;
+  artistUrl?: string;
   avatarUrl: string;
   artworkUrl: string;
   albumId: string;

--- a/utils/musicPlayer.ts
+++ b/utils/musicPlayer.ts
@@ -1,35 +1,6 @@
-import { Track } from "./api";
+import TrackPlayer, { State } from "react-native-track-player";
 
-export const formatTrackListForMusicPlayer = (trackList: Track[]) => {
-  return trackList.map(
-    ({
-      id,
-      liveUrl,
-      artworkUrl,
-      title,
-      artist,
-      artistId,
-      avatarUrl,
-      albumId,
-      albumTitle,
-      duration,
-    }) => ({
-      id,
-      liveUrl,
-      artworkUrl,
-      title,
-      artist,
-      artistId,
-      avatarUrl,
-      albumId,
-      albumTitle,
-      durationInMs: duration * 1000,
-    }),
-  );
-};
-
-export const formatTime = (milliseconds: number) => {
-  const totalSeconds = Math.max(Math.floor(milliseconds / 1000), 0);
+export const formatTime = (totalSeconds: number) => {
   const hours = Math.floor(totalSeconds / 3600);
   const minutes = Math.floor((totalSeconds % 3600) / 60);
   const seconds = totalSeconds % 60;
@@ -38,4 +9,39 @@ export const formatTime = (milliseconds: number) => {
   const normalizedSeconds = `${seconds}`.padStart(2, "0");
 
   return `${normalizedHours}${normalizedMinutes}${normalizedSeconds}`;
+};
+
+export const canSkipToPrevious = async () => {
+  const position = await TrackPlayer.getPosition();
+  const currentTrack = (await TrackPlayer.getCurrentTrack()) ?? 0;
+
+  return position < 5 && currentTrack > 0;
+};
+
+export const skipToPrevious = async () => {
+  const canSkip = await canSkipToPrevious();
+
+  if (canSkip) {
+    await TrackPlayer.skipToPrevious();
+  } else {
+    await TrackPlayer.seekTo(0);
+  }
+};
+
+export const skipToNext = async () => {
+  await TrackPlayer.skipToNext();
+};
+
+export const togglePlayPause = async () => {
+  const state = await TrackPlayer.getState();
+
+  if (state !== State.Paused) {
+    await TrackPlayer.pause();
+  } else if (state === State.Paused) {
+    await TrackPlayer.play();
+  }
+};
+
+export const seekTo = async (seconds: number) => {
+  await TrackPlayer.seekTo(seconds);
 };

--- a/utils/nostr.ts
+++ b/utils/nostr.ts
@@ -263,16 +263,16 @@ interface MakeLiveStatusEventParams {
   pubkey: string;
   trackUrl: string;
   content: string;
-  durationInMs: number;
-  relayUris: string[];
+  duration: number;
+  relayUris?: string[];
 }
 
 export const publishLiveStatusEvent = async ({
   pubkey,
   trackUrl,
   content,
-  durationInMs,
-  relayUris,
+  duration,
+  relayUris = DEFAULT_WRITE_RELAY_URIS,
 }: MakeLiveStatusEventParams) => {
   const { allowListeningActivity } = await getSettings(pubkey);
 
@@ -292,7 +292,7 @@ export const publishLiveStatusEvent = async ({
     tags: [
       ["d", "music"],
       ["r", trackUrl],
-      ["expiration", (currentTime + durationInMs / 1000).toString()],
+      ["expiration", (currentTime + duration).toString()],
     ],
   };
   const signedEvent = await signEvent(eventTemplate);

--- a/utils/secureStorage.ts
+++ b/utils/secureStorage.ts
@@ -1,4 +1,5 @@
 import * as SecureStore from "expo-secure-store";
+import { getPublicKey } from "nostr-tools";
 
 const seckey = "seckey";
 
@@ -12,4 +13,14 @@ export const getSeckey = async () => {
 
 export const deleteSeckey = async () => {
   await SecureStore.deleteItemAsync(seckey);
+};
+
+export const getPubkeyFromCachedSeckey = async () => {
+  try {
+    const seckey = await getSeckey();
+
+    return seckey ? getPublicKey(seckey) : "";
+  } catch {
+    return "";
+  }
 };


### PR DESCRIPTION
Swapped the music player library in order to get music player controls on the lock screen. For development, you'll need to use expo-dev-client instead of expo go from now on. You can use this dev build to test this PR locally https://expo.dev/accounts/wavlake/projects/mobile/builds/5db95b59-4989-4515-981b-5c93989d074b. You'll need to uninstall the TestFlight app in order to install the dev build. The command to start the app with expo-dev-client is exactly the same as expo go.