### PR TITLE
use default relays to broadcast live statuses when necessary

### DIFF
--- a/components/MusicPlayerProvider.tsx
+++ b/components/MusicPlayerProvider.tsx
@@ -109,9 +109,10 @@ export const MusicPlayerProvider = ({ children }: PropsWithChildren) => {
       return;
     }
 
-    const writeRelayList = getWriteRelayUris(
-      await getCachedNostrRelayListEvent(pubkey),
-    );
+    const relayListEvent = await getCachedNostrRelayListEvent(pubkey);
+    const writeRelayList = relayListEvent
+      ? getWriteRelayUris(relayListEvent)
+      : null;
     await publishLiveStatusEvent({
       pubkey,
       trackUrl: `https://wavlake.com/track/${track.id}`,

--- a/components/MusicPlayerProvider.tsx
+++ b/components/MusicPlayerProvider.tsx
@@ -7,7 +7,6 @@ import {
 } from "react";
 import TrackPlayer, {
   Event,
-  State,
   useTrackPlayerEvents,
 } from "react-native-track-player";
 import {

--- a/utils/cache.ts
+++ b/utils/cache.ts
@@ -59,7 +59,9 @@ export const cacheNostrRelayListEvent = async (
   await storeObjectData(nostrRelayListEventKey, event);
 };
 
-export const getCachedNostrRelayListEvent = async (pubkey: string) => {
+export const getCachedNostrRelayListEvent = async (
+  pubkey: string,
+): Promise<Event | null> => {
   const nostrRelayListEventKey = makeNostrRelayListEventKey(pubkey);
 
   return getObjectData(nostrRelayListEventKey);


### PR DESCRIPTION
this fixes a bug that caused live statuses not to be published if no relay list found for user.