### PR TITLE
move nostr event loading to inbox page

### DIFF
--- a/components/Inbox/index.tsx
+++ b/components/Inbox/index.tsx
@@ -1,11 +1,16 @@
+import { useEffect } from "react";
+import { ActivityIndicator } from "react-native";
 import { PillTabView } from "../PillTabView";
 import { ContentTab } from "./ContentTab";
 import { NonContentTab } from "./NonContentTab";
 import { useInbox } from "@/hooks";
-import { useEffect } from "react";
+import { useNostrEvents } from "@/providers/NostrEventProvider";
+import { Center } from "../shared/Center";
 
 export const InboxPage = () => {
   const {
+    loadInitialData,
+    isLoadingInitial,
     updateLastRead,
     comments,
     contentComments,
@@ -18,9 +23,17 @@ export const InboxPage = () => {
   } = useInbox();
 
   useEffect(() => {
-    // update last read date on mount
+    loadInitialData();
     updateLastRead();
   }, []);
+
+  if (isLoadingInitial) {
+    return (
+      <Center>
+        <ActivityIndicator size="large" />
+      </Center>
+    );
+  }
 
   return userHasContent ? (
     <PillTabView tabNames={["Wavlake", "Other"]}>


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Move the responsibility for loading Nostr events from the provider to the `InboxPage`, ensuring that the initial data is loaded directly in the `Inbox` component and displaying a loading indicator while this data is being fetched.

### Why are these changes being made?

This refactor centralizes data loading within the `InboxPage` for improved separation of concerns and responsiveness. By moving the data loading to the `InboxPage`, we ensure that the component itself manages its loading state and display, leading to a clearer flow of data and rendering logic, which is more maintainable and potentially less error-prone. Moreover, users will benefit from immediate feedback when data is loading with the help of a loading indicator.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->