### PR TITLE
Add profile picture upload disclosure modal and handling logic

### DIFF
--- a/utils/cache.ts
+++ b/utils/cache.ts
@@ -144,3 +144,9 @@ export const getAmberPubkey = async () => {
 export const setAmberPubkey = async (pubkey: string) => {
   await storeData("amberPubkey", pubkey);
 };
+
+const DISCLOSURE_KEY = "profile_picture_disclosure_accepted";
+
+export const setImageDisclosure = () =>
+  AsyncStorage.setItem(DISCLOSURE_KEY, "true");
+export const getImageDisclosure = () => AsyncStorage.getItem(DISCLOSURE_KEY);


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add a modal for profile picture upload disclosure and implement handling logic for user consent.

### Why are these changes being made?
To ensure compliance with data collection regulations, users must explicitly accept a disclosure notice before uploading their profile pictures. This approach provides a clear user interface for consent, with persistent storage of acceptance status using AsyncStorage.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->